### PR TITLE
add a cascading merge

### DIFF
--- a/src/tink/Anon.hx
+++ b/src/tink/Anon.hx
@@ -14,13 +14,25 @@ class Anon {
     var ct = type.toComplex();
     return
       mergeExpressions(
-        exprs, 
+        exprs,
         requiredFields(type),
         ct
       );
   }
 
-  macro static public function splat(e:Expr, ?prefix:Expr, ?filter:Expr) 
+  public static macro function cascade<T>(exprs : Array<ExprOf<T>>) : Expr {
+    var type = Context.getExpectedType();
+    var ct = type.toComplex();
+    return
+      mergeExpressions(
+        exprs,
+        requiredFields(type),
+        ct,
+        true
+      );
+  }
+
+  macro static public function splat(e:Expr, ?prefix:Expr, ?filter:Expr)
     return makeSplat(e, prefix, filter);
 
 }


### PR DESCRIPTION
I have a utility function that merges several anonymous object types together, similar to tink.Anon.merge.  However, my merge function allows for fields to override each other.  This can be useful if you're working with configuration, and want to provide a series of overrides.

I'm calling this type of merge a "cascade", and provided a new implementation here.

Apologies for the other whitespace changes, I strip things out automatically when I write buffers.  I'll mark the relevant changes.