### PR TITLE
add a cascading merge

### DIFF
--- a/src/tink/Anon.hx
+++ b/src/tink/Anon.hx
@@ -20,6 +20,18 @@ class Anon {
       );
   }
 
+  public static macro function cascade<T>(exprs : Array<ExprOf<T>>) : Expr {
+    var type = Context.getExpectedType();
+    var ct = type.toComplex();
+    return
+      mergeExpressions(
+        exprs,
+        requiredFields(type),
+        ct,
+        true
+      );
+  }
+
   macro static public function splat(e:Expr, ?prefix:Expr, ?filter:Expr) 
     return makeSplat(e, prefix, filter);
 

--- a/src/tink/anon/Macro.hx
+++ b/src/tink/anon/Macro.hx
@@ -45,13 +45,14 @@ class Macro {
     });
   }
   
-  static public function mergeExpressions(exprs:Array<Expr>, ?requiredType, ?pos, ?as) {
+  static public function mergeExpressions(exprs:Array<Expr>, ?requiredType, ?pos, ?as, accept_first=false) {
     var complex = [],
         individual = [];
 
     function add(name, expr, pos)
       individual.push({ name: name, getValue: function (_) return expr, pos: pos });
 
+    var field_names = new Map<String,Int>();
     for (e in exprs) 
       switch e {
         case macro $name = $v:
@@ -59,8 +60,13 @@ class Macro {
 
         case { expr: EObjectDecl(fields) }:
 
-          for (f in fields)
+          for (f in fields){
+            if (accept_first){
+              if (field_names.exists(f.field)) continue;
+              field_names.set(f.field, 1);
+            }
             add(f.field, f.expr, f.expr.pos);
+          }
 
         default: 
           complex.push(e);


### PR DESCRIPTION
I have a utility function that merges several anonymous object types together, similar to tink.Anon.merge. However, my merge function allows for fields to override each other. This can be useful if you're working with configuration, and want to provide a series of overrides.

For my implementation, the first field with a given name is preserved, subsequent fields in other anonymous types that share the name are ignored.  I'm calling this type of merge a "cascade", and provided a new implementation here.
