### PR TITLE
Add replace()

### DIFF
--- a/src/tink/Anon.hx
+++ b/src/tink/Anon.hx
@@ -22,5 +22,8 @@ class Anon {
 
   macro static public function splat(e:Expr, ?prefix:Expr, ?filter:Expr) 
     return makeSplat(e, prefix, filter);
+    
+  macro static public function replace(exprs:Array<Expr>) 
+    return makeReplace(exprs[0], exprs.slice(1));
 
 }

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -71,6 +71,13 @@ class RunTests extends TestCase {
     assertEquals('foo', o.foo());
   }
   
+  function testReplace() {
+    var o = {a: 1, b: 2};
+    var o1 = replace(o, a = 2, {b: 1});
+    assertEquals(2, o1.a);
+    assertEquals(1, o1.b);
+  }
+  
   function testStructInit() {
     var o = { beep: 5, bop: 4, foo: 2 };
     var o2:Example = tink.Anon.merge(o, foo = 3, bar = 5);


### PR DESCRIPTION
```haxe
var o = {a:1, b:2, c:3};
var o1 = replace(o, a = 4, {b:5});
```

gets translated into:

```haxe
var o1 = {
  a: 4,
  b: 5,
  c: o.c,
}
```