### PR TITLE
Add tink.Anon.transform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: required
-dist: trusty
+dist: xenial
 
 stages:
   - test
   - deploy
 
 language: node_js
-node_js: 8
+node_js: 12
 
 os:
   - linux

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -161,6 +161,60 @@ class RunTests extends TestCase {
     assertEquals(13, ab.b);
 
   }
+  
+  function testTransform() {
+    var o:{a:Int, ?b:Int, c:{e:Int, ?f:Int}, ?d:{g:Int, ?h:Int}} = {a: 1, c: {e: 2}}
+    var t = transform(o, {
+      a: v -> v + 1,
+      b: v -> v + 1,
+      c: {
+        e: v -> v + 1,
+        f: v -> v + 1,
+      },
+      d: {
+        g: v -> v + 1,
+        h: v -> v + 1,
+      }
+    });
+    assertEquals(2, t.a);
+    assertEquals(3, t.c.e);
+    assertFalse(Reflect.hasField(t, 'b'));
+    assertFalse(Reflect.hasField(t, 'd'));
+    assertFalse(Reflect.hasField(t.c, 'f'));
+    
+    var o:{a:Int, ?b:Int, c:{e:Int, ?f:Int}, ?d:{g:Int, ?h:Int}} = {a: 1, b: 2, c: {e: 3, f: 4}, d: {g: 5, h: 6}}
+    var t = transform(o, {
+      a: v -> v + 1,
+      b: v -> v + 1,
+      c: {
+        e: v -> v + 1,
+        f: v -> v + 1,
+      },
+      d: {
+        g: v -> v + 1,
+        h: v -> v + 1,
+      }
+    });
+    assertEquals(2, t.a);
+    assertEquals(3, t.b);
+    assertEquals(4, t.c.e);
+    assertEquals(5, t.c.f);
+    assertEquals(6, t.d.g);
+    assertEquals(7, t.d.h);
+    
+    
+    var o:{a:Int, ?b:Int, c:{e:Int, ?f:Int}, ?d:{g:Int, ?h:Int}} = {a: 1, c: {e: 3, f: 4}}
+    var t = transform(o, {c: v -> v.e});
+    assertEquals(1, t.a);
+    assertEquals(3, t.c);
+    
+    #if haxe4
+    var o:{final a:Int; final ?b:Int; final c:{e:Int, ?f:Int}; final ?d:{g:Int, ?h:Int};} = {a: 1, c: {e: 3, f: 4}}
+    var t = transform(o, {c: v -> v.e});
+    assertEquals(1, t.a);
+    assertEquals(3, t.c);
+    #end
+  }
 
   static function main() {
     var r = new TestRunner();

--- a/tests/RunTests.hx
+++ b/tests/RunTests.hx
@@ -192,7 +192,7 @@ class RunTests extends TestCase {
       },
       d: {
         g: v -> v + 1,
-        h: v -> v + 1,
+        h: v -> v * v,
       }
     });
     assertEquals(2, t.a);
@@ -200,8 +200,7 @@ class RunTests extends TestCase {
     assertEquals(4, t.c.e);
     assertEquals(5, t.c.f);
     assertEquals(6, t.d.g);
-    assertEquals(7, t.d.h);
-    
+    assertEquals(36, t.d.h);
     
     var o:{a:Int, ?b:Int, c:{e:Int, ?f:Int}, ?d:{g:Int, ?h:Int}} = {a: 1, c: {e: 3, f: 4}}
     var t = transform(o, {c: v -> v.e});
@@ -213,6 +212,7 @@ class RunTests extends TestCase {
     var t = transform(o, {c: v -> v.e});
     assertEquals(1, t.a);
     assertEquals(3, t.c);
+    // t.a = 1; // can't write to final
     #end
   }
 


### PR DESCRIPTION
This adds `tink.Anon.transform` that will perform per-field transformation for a given anon object.

The function takes two expressions:
- the first argument is the "target" object to be transformed, it must be of anon type
- the second argument is the "patch" object, it must be an object literal

Each field in the patch object (if exists) should be a transformation function, to be acted against the same-named field in the target object.

If a target field is an anon object, the corresponding patch field can also be an object literal in additional to a function. This will allow nesting of transformations.

Example:

```haxe
tink.Anon.transform(
  {a: 1, b: {c: 2}, d: 3},
  {a: v -> v + 1, b: {c: v -> v * v}
);
```

will transform into:

```haxe
var o = {a: 1, b: {c: 2}, d: 3}
{
  a: (v -> v + 1)(o.a),
  b: {
    c: (v -> v * v)(o.b.c),
  },
  d: o.d,
}
```

Note that `Reflect.hasField` is used on optional fields, so that non-existent fields will remain non-existent in the result object
